### PR TITLE
Remove px-buttons-design dependency

### DIFF
--- a/_objects.input-group.scss
+++ b/_objects.input-group.scss
@@ -5,7 +5,12 @@
 ////
 
 @import "px-forms-design/_base.forms.scss";
-@import "px-buttons-design/_objects.buttons.scss";
+
+// commented out because we just want the variables, not the styles
+// @import "px-buttons-design/_objects.buttons.scss";
+
+/// @type String [default] - Prepend value for all generated classes
+$inuit-btn-namespace            : $inuit-namespace !default;
 
 /// @type String [default] - Prepend value for all generated classes
 $inuit-input-group-namespace    : $inuit-namespace !default;

--- a/bower.json
+++ b/bower.json
@@ -23,7 +23,6 @@
     "tests"
   ],
   "dependencies": {
-    "px-buttons-design": "https://github.com/PredixDev/px-buttons-design.git#~0.4.0",
     "px-forms-design": "https://github.com/PredixDev/px-forms-design.git#~0.3.0"
   },
   "devDependencies" : {


### PR DESCRIPTION
Reviewing the Sass for px-input-group-design, it appears the only reason px-buttons-design is being included is to ensure the `$inuit-btn-namespace` variable is available.

If you author a Predix UI component that includes both px-buttons-design and px-input-group-design, the resulting compiled CSS will include the `.btn` classes twice; once when px-buttons-design is imported as itself, and once when px-buttons-design is imported as a dependency of px-input-group-design. This can lead to version conflicts, unpredictable class style behavior, and can impact the cleanliness of your component's ITCSS layers.

This pull request removes the px-buttons-design dependency from px-input-group-design and defines the `$inuit-btn-namespace` directly in its `.scss` file.
